### PR TITLE
Detect externally-started servers via port probing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,15 @@ toml = "0.8"
 dirs = "6"
 
 # Hide the console window on Windows release builds; winreg for the
-# HKCU Run-key toggle that backs "Start with Windows".
+# HKCU Run-key toggle that backs "Start with Windows"; IpHelper/WinSock
+# for the TCP listener table behind external-server detection.
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.58", features = ["Win32_System_Console", "Win32_UI_WindowsAndMessaging"] }
+windows = { version = "0.58", features = [
+    "Win32_System_Console",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_Networking_WinSock",
+] }
 winreg = "0.52"
 
 # build.rs renders the tray-icon RGBA blob and the exe .ico from

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -3,7 +3,8 @@
 ## Overview
 Windows system tray app for managing dev servers. Single Rust binary, no runtime deps.
 
-## Current State (2026-05-19)
+## Current State (2026-07-03)
+- **External server detection (#24):** optional `port` field per `[[server]]`; servers started outside the app (terminal, AI dev session) show as `[external]` via the Windows TCP listener table (`GetExtendedTcpTable`, IPv4+IPv6). Stop kills the detected PID tree, Restart adopts the server under app management, Start refuses when the port is externally occupied. New "Refresh Status" menu item + auto-refresh on tray-icon hover (menu swapped in place via `set_menu`, no icon flicker). Config reload ignores port-only changes. First unit tests added (config parsing, port probe, detection logic) — `cargo test`. Manually verified against the reader-app prod frontend on 2026-07-03.
 - **v0.2.0 released** — https://github.com/paperhurts/server-start/releases/tag/v0.2.0
 - **v0.1.0** — https://github.com/paperhurts/server-start/releases/tag/v0.1.0
 - All code review issues resolved (#1-#8)
@@ -24,9 +25,10 @@ Windows system tray app for managing dev servers. Single Rust binary, no runtime
 - `src/main.rs` — tray icon, menu building, event loop (winit + tray-icon)
 - `src/autostart.rs` — HKCU Run-key toggle for "Start with Windows" (Windows-only)
 - `src/config.rs` — TOML config parsing, OutputMode enum, GroupConfig, log path helpers
-- `src/process.rs` — process spawning (3 modes), kill trees, config reload diffing, group operations
+- `src/ports.rs` — Windows TCP listener table probe (port → owning PID) for external-server detection
+- `src/process.rs` — process spawning (3 modes), kill trees, RunState (running/external/stopped), config reload diffing, group operations
 - `src/errors.rs` — MessageBoxW wrapper for user-visible error dialogs
 
 ## Open Issues
-- No automated tests
+- Test coverage is minimal (unit tests exist for config parsing, port probe, and external detection; nothing for spawning/menu logic)
 - No CI pipeline

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A lightweight Windows system tray app for managing dev servers across multiple p
 - **Bulk actions** — Start All, Stop All, Restart All
 - **Start with Windows** — tray checkbox that registers the app to launch automatically at user logon
 - **Restart Terminals** — kills all PowerShell/pwsh/Windows Terminal sessions and opens a fresh one (asks for confirmation first)
+- **External detection** — servers started outside the app (a terminal, an AI dev session) show as `[external]` when a `port` is configured; Stop/Restart work on them
 - **Hot-reload config** — edit your config and reload without restarting the app (running servers with unchanged config stay running)
 - **Open Config** — jump straight to your config file from the tray menu
 - **Error dialogs** — config errors and server failures show Windows message boxes (no silent failures)
@@ -49,6 +50,7 @@ Add your dev servers:
 name = "Frontend"
 dir = "C:/dev/my-app"
 cmd = "npm run dev"
+port = 5173          # optional: detect externally-started instances
 
 [[server]]
 name = "Backend API"
@@ -72,6 +74,7 @@ Each `[[server]]` block defines one process:
 | `cmd`    | yes      | The command to run                                |
 | `env`    | no       | Extra environment variables to set                |
 | `output` | no       | `"terminal"`, `"logfile"`, or `"hidden"` (overrides global) |
+| `port`   | no       | TCP port the server listens on; enables `[external]` detection of instances started outside the app |
 
 ### Groups
 
@@ -112,7 +115,8 @@ Right-click the tray icon to see your servers and controls:
 
 - Each server has a submenu with **Start**, **Stop**, **Restart**, and **Mode** (Terminal/Logfile/Hidden)
 - Logfile-mode servers also have a **View Log** option
-- Status shows as `[running]` or `[stopped]` (auto-detects crashes)
+- Status shows as `[running]`, `[external]`, or `[stopped]` (auto-detects crashes)
+- **Refresh Status** re-probes everything on demand; statuses also refresh automatically when you hover the tray icon, so the menu is current when it opens
 - **Groups** show running count and have **Start/Stop/Restart Group** actions
 - **Start/Stop/Restart All Servers** for bulk control
 - **Restart Terminals** to kill and reopen all terminal windows (shows confirmation first — this kills *all* open terminals, not just ones managed by the app)
@@ -136,6 +140,12 @@ The registry is the single source of truth — there's no shadow state in `confi
 Servers themselves do not auto-start on launch; the app comes up with everything stopped, same as a normal launch.
 
 > **Note:** Stopping/restarting a server kills its entire process tree. If you're running Claude or another tool inside a terminal that a configured server spawned, it will be killed when that server is stopped.
+
+### External detection
+
+If a `[[server]]` has a `port`, the app checks Windows' TCP listener table for it. When something is listening on that port but wasn't started by the app, the server shows as `[external]` — typical when a dev server was launched from a terminal or by an AI coding session. **Stop** kills the detected process's tree (its parent shell survives), and **Restart** relaunches the server under the app's own management.
+
+> **Caveat:** detection is purely port-based. If an unrelated program happens to listen on a configured port, it will show as `[external]` — and **Stop will kill that program's process tree**. Pick ports that only your dev servers use.
 
 ## Built With
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,12 +45,26 @@ pub struct ServerConfig {
     pub env: HashMap<String, String>,
     /// Per-server output mode override (uses global default if not set)
     pub output: Option<OutputMode>,
+    /// Optional: TCP port the server listens on. Enables detection of
+    /// externally-started instances (shown as [external] in the tray).
+    pub port: Option<u16>,
 }
 
 impl ServerConfig {
     /// Returns the effective output mode, preferring per-server override over global default.
     pub fn effective_output<'a>(&'a self, global: &'a OutputMode) -> &'a OutputMode {
         self.output.as_ref().unwrap_or(global)
+    }
+
+    /// True when the fields that affect process spawning are equal.
+    /// `port` is intentionally excluded: it only affects status detection,
+    /// so changing it must not restart a running server on config reload.
+    pub fn spawn_fields_eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.dir == other.dir
+            && self.cmd == other.cmd
+            && self.env == other.env
+            && self.output == other.output
     }
 }
 
@@ -103,5 +117,75 @@ impl Config {
             .collect();
         path.push(format!("{}.log", safe_name));
         path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_server_with_port() {
+        let cfg: Config = toml::from_str(
+            r#"
+            [[server]]
+            name = "web"
+            dir = "C:/x"
+            cmd = "npm run dev"
+            port = 5173
+        "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.server[0].port, Some(5173));
+    }
+
+    #[test]
+    fn port_is_optional() {
+        let cfg: Config = toml::from_str(
+            r#"
+            [[server]]
+            name = "web"
+            dir = "C:/x"
+            cmd = "npm run dev"
+        "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.server[0].port, None);
+    }
+
+    #[test]
+    fn rejects_out_of_range_port() {
+        let result: Result<Config, _> = toml::from_str(
+            r#"
+            [[server]]
+            name = "web"
+            dir = "C:/x"
+            cmd = "npm run dev"
+            port = 70000
+        "#,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn spawn_fields_eq_ignores_port() {
+        let cfg: Config = toml::from_str(
+            r#"
+            [[server]]
+            name = "web"
+            dir = "C:/x"
+            cmd = "npm run dev"
+            port = 5173
+
+            [[server]]
+            name = "web"
+            dir = "C:/x"
+            cmd = "npm run dev"
+            port = 8080
+        "#,
+        )
+        .unwrap();
+        assert!(cfg.server[0].spawn_fields_eq(&cfg.server[1]));
+        assert_ne!(cfg.server[0], cfg.server[1]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,13 @@
 mod autostart;
 mod config;
 mod errors;
+mod ports;
 mod process;
 
 use config::{Config, GroupConfig, OutputMode, ServerConfig};
-use process::{new_shared, SharedProcessManager};
+use process::{new_shared, RunState, SharedProcessManager};
 use tray_icon::menu::{CheckMenuItem, Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu};
-use tray_icon::{Icon, TrayIcon, TrayIconBuilder};
+use tray_icon::{Icon, TrayIcon, TrayIconBuilder, TrayIconEvent};
 use winit::application::ApplicationHandler;
 use winit::event::WindowEvent;
 use winit::event_loop::{ActiveEventLoop, EventLoop};
@@ -20,6 +21,7 @@ const MENU_ID_START_ALL: &str = "start_all";
 const MENU_ID_STOP_ALL: &str = "stop_all";
 const MENU_ID_RESTART_ALL: &str = "restart_all";
 const MENU_ID_RESTART_TERMINALS: &str = "restart_terminals";
+const MENU_ID_REFRESH: &str = "refresh_status";
 const MENU_ID_RELOAD_CONFIG: &str = "reload_config";
 const MENU_ID_OPEN_CONFIG: &str = "open_config";
 #[cfg(windows)]
@@ -81,11 +83,17 @@ fn main() {
 # "hidden"   = hidden, no windows, no output captured
 # output = "terminal"
 
+# ─── Port detection (optional) ───
+# If "port" is set, the tray checks whether anything is LISTENing on that
+# port. A server started outside this app (terminal, AI dev session, ...)
+# shows as [external]; Stop/Restart then act on the detected process.
+
 # ─── Example: typical full-stack setup ───
 # [[server]]
 # name = "Frontend"
 # dir = "C:/dev/my-app"
 # cmd = "npm run dev"
+# port = 5173               # optional: detect externally-started instances
 #
 # [[server]]
 # name = "Backend API"
@@ -136,6 +144,8 @@ struct App {
     _tray: Option<TrayIcon>,
     server_count: usize,
     groups: Vec<GroupConfig>,
+    /// Throttle for hover-triggered status refreshes (see hover_refresh)
+    last_hover_refresh: Option<std::time::Instant>,
 }
 
 impl App {
@@ -146,6 +156,7 @@ impl App {
             _tray: None,
             server_count,
             groups,
+            last_hover_refresh: None,
         }
     }
 
@@ -153,19 +164,29 @@ impl App {
         let menu = Menu::new();
         let mut mgr = self.manager.lock().unwrap();
 
+        // Pick up servers started/stopped outside this app before rendering
+        mgr.refresh_external();
+
         // Individual server controls
         for id in 0..self.server_count {
             let name = mgr.server_name(id).unwrap_or("Unknown").to_string();
-            let running = mgr.is_running(id);
+            let state = mgr.run_state(id);
             let current_mode = mgr.server_output_mode(id).cloned().unwrap_or_default();
-            let status = if running { " [running]" } else { " [stopped]" };
+            let status = match state {
+                RunState::Running => " [running]",
+                RunState::External => " [external]",
+                RunState::Stopped => " [stopped]",
+            };
+            // External servers are stoppable/restartable too: Stop kills the
+            // detected PID's tree; Restart then relaunches under our management
+            let stoppable = state != RunState::Stopped;
 
             let submenu = Submenu::new(format!("{}{}", name, status), true);
 
-            let start_item = MenuItem::with_id(format!("start_{}", id), "Start", !running, None);
-            let stop_item = MenuItem::with_id(format!("stop_{}", id), "Stop", running, None);
+            let start_item = MenuItem::with_id(format!("start_{}", id), "Start", !stoppable, None);
+            let stop_item = MenuItem::with_id(format!("stop_{}", id), "Stop", stoppable, None);
             let restart_item =
-                MenuItem::with_id(format!("restart_{}", id), "Restart", running, None);
+                MenuItem::with_id(format!("restart_{}", id), "Restart", stoppable, None);
 
             submenu.append(&start_item).ok();
             submenu.append(&stop_item).ok();
@@ -221,7 +242,7 @@ impl App {
                 let total = resolved.len();
                 let running = resolved.iter().filter(|name| {
                     mgr.server_id_by_name(name)
-                        .map(|id| mgr.is_running(id))
+                        .map(|id| mgr.run_state(id) != RunState::Stopped)
                         .unwrap_or(false)
                 }).count();
 
@@ -256,6 +277,11 @@ impl App {
         menu.append(&start_all).ok();
         menu.append(&stop_all).ok();
         menu.append(&restart_all).ok();
+
+        // Re-probe ports and redraw statuses on demand — catches servers
+        // started or stopped outside this app
+        let refresh = MenuItem::with_id(MENU_ID_REFRESH, "Refresh Status", true, None);
+        menu.append(&refresh).ok();
 
         menu.append(&PredefinedMenuItem::separator()).ok();
 
@@ -302,6 +328,14 @@ impl App {
 
     fn rebuild_tray(&mut self) {
         let menu = self.build_menu();
+
+        // Swap the menu on the existing tray icon — recreating the whole
+        // TrayIcon makes it flicker in the notification area
+        if let Some(tray) = &self._tray {
+            tray.set_menu(Some(Box::new(menu)));
+            return;
+        }
+
         let icon = create_icon();
 
         match TrayIconBuilder::new()
@@ -319,14 +353,36 @@ impl App {
         }
     }
 
+    /// Refresh statuses when the mouse is over the tray icon, so the menu is
+    /// already up to date when the user right-clicks — the context menu opens
+    /// synchronously on click, so a post-click rebuild would be too late.
+    /// Throttled to once per second; skipped when no server has a port
+    /// configured (nothing external to detect).
+    fn hover_refresh(&mut self) {
+        if !self.manager.lock().unwrap().any_ports_configured() {
+            return;
+        }
+        let now = std::time::Instant::now();
+        if self
+            .last_hover_refresh
+            .is_some_and(|t| now.duration_since(t) < std::time::Duration::from_secs(1))
+        {
+            return;
+        }
+        self.last_hover_refresh = Some(now);
+        self.rebuild_tray();
+    }
+
     fn handle_menu_event(&mut self, event: MenuEvent, event_loop: &ActiveEventLoop) {
         let id = event.id().0.as_str();
 
         match id {
             MENU_ID_QUIT => {
+                // Count external servers too — "stop all" will kill them as well
                 let has_running = {
                     let mut mgr = self.manager.lock().unwrap();
-                    (0..mgr.server_count()).any(|id| mgr.is_running(id))
+                    mgr.refresh_external();
+                    (0..mgr.server_count()).any(|id| mgr.run_state(id) != RunState::Stopped)
                 };
                 if has_running
                     && errors::confirm(
@@ -352,6 +408,10 @@ impl App {
             }
             MENU_ID_RESTART_TERMINALS => {
                 process::restart_terminals();
+            }
+            MENU_ID_REFRESH => {
+                // build_menu() re-probes the port table
+                self.rebuild_tray();
             }
             MENU_ID_OPEN_CONFIG => {
                 let path = Config::config_path();
@@ -504,8 +564,16 @@ impl ApplicationHandler for App {
     }
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
-        if let Ok(event) = MenuEvent::receiver().try_recv() {
+        while let Ok(event) = MenuEvent::receiver().try_recv() {
             self.handle_menu_event(event, event_loop);
+        }
+        // Mouse-over-tray events arrive in bursts (Move fires repeatedly), so
+        // drain the channel rather than handling one per wake
+        while let Ok(event) = TrayIconEvent::receiver().try_recv() {
+            match event {
+                TrayIconEvent::Enter { .. } | TrayIconEvent::Move { .. } => self.hover_refresh(),
+                _ => {}
+            }
         }
     }
 }

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -1,0 +1,143 @@
+//! TCP listener table probe, backing external-server detection.
+//!
+//! A server config may declare the TCP `port` it listens on. If that port is
+//! LISTENing but the process wasn't spawned by us, it was started externally
+//! (a terminal, an AI dev session, ...) and the tray shows it as [external].
+
+use std::collections::HashMap;
+
+/// Snapshot of all listening TCP ports (IPv4 + IPv6) mapped to the owning PID.
+/// If a port has both an IPv4 and an IPv6 listener, the first insertion wins —
+/// in practice both belong to the same process, so either PID works for taskkill.
+#[cfg(windows)]
+pub fn listening_ports() -> HashMap<u16, u32> {
+    let mut map = HashMap::new();
+    win::collect_v4(&mut map);
+    win::collect_v6(&mut map);
+    map
+}
+
+/// Non-Windows stub: no detection, everything reads as not listening.
+#[cfg(not(windows))]
+pub fn listening_ports() -> HashMap<u16, u32> {
+    HashMap::new()
+}
+
+/// Whether anything is currently listening on `port`. Used to wait for a port
+/// to be released after killing an external process (no Child handle to wait on).
+pub fn port_listening(port: u16) -> bool {
+    listening_ports().contains_key(&port)
+}
+
+#[cfg(windows)]
+mod win {
+    use std::collections::HashMap;
+
+    use windows::Win32::Foundation::{ERROR_INSUFFICIENT_BUFFER, NO_ERROR, TRUE};
+    use windows::Win32::NetworkManagement::IpHelper::{
+        GetExtendedTcpTable, MIB_TCP6ROW_OWNER_PID, MIB_TCP6TABLE_OWNER_PID, MIB_TCPROW_OWNER_PID,
+        MIB_TCPTABLE_OWNER_PID, TCP_TABLE_OWNER_PID_LISTENER,
+    };
+    use windows::Win32::Networking::WinSock::{AF_INET, AF_INET6};
+
+    /// Fetch a TCP owner-PID listener table for one address family via the
+    /// two-call sizing pattern. Returns the raw table buffer, or None on failure.
+    /// Retries a few times because the table can grow between the sizing call
+    /// and the fetch.
+    fn fetch_table(family: u32) -> Option<Vec<u8>> {
+        unsafe {
+            let mut size: u32 = 0;
+            let rc = GetExtendedTcpTable(
+                None,
+                &mut size,
+                TRUE,
+                family,
+                TCP_TABLE_OWNER_PID_LISTENER,
+                0,
+            );
+            if rc != NO_ERROR.0 && rc != ERROR_INSUFFICIENT_BUFFER.0 {
+                return None;
+            }
+
+            for _ in 0..3 {
+                let mut buf = vec![0u8; size.max(16) as usize];
+                let rc = GetExtendedTcpTable(
+                    Some(buf.as_mut_ptr().cast()),
+                    &mut size,
+                    TRUE,
+                    family,
+                    TCP_TABLE_OWNER_PID_LISTENER,
+                    0,
+                );
+                if rc == ERROR_INSUFFICIENT_BUFFER.0 {
+                    continue; // size was updated; retry with a larger buffer
+                }
+                if rc != NO_ERROR.0 {
+                    return None;
+                }
+                return Some(buf);
+            }
+            None
+        }
+    }
+
+    pub(super) fn collect_v4(out: &mut HashMap<u16, u32>) {
+        let Some(buf) = fetch_table(AF_INET.0 as u32) else {
+            return;
+        };
+        unsafe {
+            let table = buf.as_ptr() as *const MIB_TCPTABLE_OWNER_PID;
+            let rows = std::ptr::addr_of!((*table).table) as *const MIB_TCPROW_OWNER_PID;
+            let offset = rows as usize - table as usize;
+            // Bound by the actual buffer size in case the reported count overruns it
+            let max_rows =
+                buf.len().saturating_sub(offset) / std::mem::size_of::<MIB_TCPROW_OWNER_PID>();
+            let n = ((*table).dwNumEntries as usize).min(max_rows);
+            for i in 0..n {
+                let row = &*rows.add(i);
+                // dwLocalPort is network byte order in the low 16 bits
+                let port = u16::from_be(row.dwLocalPort as u16);
+                out.entry(port).or_insert(row.dwOwningPid);
+            }
+        }
+    }
+
+    pub(super) fn collect_v6(out: &mut HashMap<u16, u32>) {
+        let Some(buf) = fetch_table(AF_INET6.0 as u32) else {
+            return;
+        };
+        unsafe {
+            let table = buf.as_ptr() as *const MIB_TCP6TABLE_OWNER_PID;
+            let rows = std::ptr::addr_of!((*table).table) as *const MIB_TCP6ROW_OWNER_PID;
+            let offset = rows as usize - table as usize;
+            let max_rows =
+                buf.len().saturating_sub(offset) / std::mem::size_of::<MIB_TCP6ROW_OWNER_PID>();
+            let n = ((*table).dwNumEntries as usize).min(max_rows);
+            for i in 0..n {
+                let row = &*rows.add(i);
+                let port = u16::from_be(row.dwLocalPort as u16);
+                out.entry(port).or_insert(row.dwOwningPid);
+            }
+        }
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    #[test]
+    fn detects_own_listener() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let map = super::listening_ports();
+        assert_eq!(map.get(&port), Some(&std::process::id()));
+        assert!(super::port_listening(port));
+    }
+
+    #[test]
+    fn detects_own_v6_listener() {
+        let listener = std::net::TcpListener::bind("[::1]:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let map = super::listening_ports();
+        assert_eq!(map.get(&port), Some(&std::process::id()));
+    }
+}

--- a/src/process.rs
+++ b/src/process.rs
@@ -5,6 +5,17 @@ use std::sync::{Arc, Mutex};
 use crate::config::{Config, OutputMode, ServerConfig};
 use crate::errors;
 
+/// How a server is currently running, as far as we can tell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunState {
+    /// We own a live child process
+    Running,
+    /// No child of ours, but the configured port is listening — started
+    /// outside this app (terminal, AI dev session, ...)
+    External,
+    Stopped,
+}
+
 pub struct ProcessManager {
     processes: Vec<ManagedProcess>,
     global_output: OutputMode,
@@ -13,6 +24,9 @@ pub struct ProcessManager {
 struct ManagedProcess {
     config: ServerConfig,
     child: Option<Child>,
+    /// PID owning the configured port when it's listening but we have no
+    /// child — i.e. the server was started externally. Set by refresh_external.
+    external_pid: Option<u32>,
 }
 
 impl ProcessManager {
@@ -22,6 +36,7 @@ impl ProcessManager {
             .map(|config| ManagedProcess {
                 config,
                 child: None,
+                external_pid: None,
             })
             .collect();
         ProcessManager {
@@ -38,6 +53,12 @@ impl ProcessManager {
 
         if proc.child.is_some() {
             return Err(format!("'{}' is already running", proc.config.name));
+        }
+        if let Some(pid) = proc.external_pid {
+            return Err(format!(
+                "'{}' is already running externally (PID {})",
+                proc.config.name, pid
+            ));
         }
 
         let mode = proc.config.effective_output(&self.global_output);
@@ -57,6 +78,16 @@ impl ProcessManager {
             // Wait for the process to actually exit (up to ~2 seconds)
             // to avoid port-already-in-use races on restart
             wait_for_exit(&mut child);
+        } else if let Some(pid) = proc.external_pid.take() {
+            // Externally-started server detected via its port. Never taskkill
+            // the Idle/System pseudo-PIDs.
+            if pid > 4 {
+                kill_process_tree(pid);
+                // No Child handle to wait on — poll the port instead
+                if let Some(port) = proc.config.port {
+                    wait_for_port_release(port);
+                }
+            }
         }
         Ok(())
     }
@@ -85,6 +116,42 @@ impl ProcessManager {
         } else {
             false
         }
+    }
+
+    /// Probe the TCP listener table once and update external detection on
+    /// every server. A server we own a live child for is never marked external.
+    pub fn refresh_external(&mut self) {
+        let table = crate::ports::listening_ports();
+        self.refresh_external_with(&table);
+    }
+
+    /// Testable core of refresh_external: takes a port → PID snapshot.
+    pub fn refresh_external_with(&mut self, table: &std::collections::HashMap<u16, u32>) {
+        for id in 0..self.processes.len() {
+            let child_alive = self.is_running(id); // also clears stale child handles
+            let proc = &mut self.processes[id];
+            proc.external_pid = match (child_alive, proc.config.port) {
+                (false, Some(port)) => table.get(&port).copied(),
+                _ => None,
+            };
+        }
+    }
+
+    /// Current run state, combining our child handle with external detection.
+    /// External state is as of the last refresh_external call.
+    pub fn run_state(&mut self, id: usize) -> RunState {
+        if self.is_running(id) {
+            RunState::Running
+        } else if self.processes.get(id).and_then(|p| p.external_pid).is_some() {
+            RunState::External
+        } else {
+            RunState::Stopped
+        }
+    }
+
+    /// Whether any server has a port configured (external detection possible).
+    pub fn any_ports_configured(&self) -> bool {
+        self.processes.iter().any(|p| p.config.port.is_some())
     }
 
     /// Returns the effective output mode for a server
@@ -208,14 +275,19 @@ impl ProcessManager {
 
             if let Some(idx) = existing_idx {
                 let old = &mut self.processes[idx];
-                if old.config == new_config {
+                // Compare only spawn-relevant fields: a changed `port` must not
+                // restart a running server (it only affects status detection)
+                if old.config.spawn_fields_eq(&new_config) {
                     // Config unchanged — transfer the child handle
                     new_processes.push(ManagedProcess {
                         config: new_config,
                         child: old.child.take(),
+                        external_pid: old.external_pid.take(),
                     });
                 } else {
-                    // Config changed — stop the old one
+                    // Config changed — stop the old one. External processes are
+                    // left alone (we didn't spawn them); detection repopulates
+                    // on the next refresh.
                     if let Some(mut child) = old.child.take() {
                         kill_process_tree(child.id());
                         wait_for_exit(&mut child);
@@ -223,6 +295,7 @@ impl ProcessManager {
                     new_processes.push(ManagedProcess {
                         config: new_config,
                         child: None,
+                        external_pid: None,
                     });
                 }
             } else {
@@ -230,6 +303,7 @@ impl ProcessManager {
                 new_processes.push(ManagedProcess {
                     config: new_config,
                     child: None,
+                    external_pid: None,
                 });
             }
         }
@@ -366,6 +440,82 @@ fn wait_for_exit(child: &mut Child) {
             Ok(None) => std::thread::sleep(std::time::Duration::from_millis(100)),
             Err(_) => return,
         }
+    }
+}
+
+/// Wait up to ~2 seconds for a port to leave the LISTEN table after killing
+/// an external process — there's no Child handle to wait on, so poll the
+/// port to avoid port-already-in-use races on restart.
+fn wait_for_port_release(port: u16) {
+    for _ in 0..20 {
+        if !crate::ports::port_listening(port) {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn test_server(name: &str, port: Option<u16>) -> ServerConfig {
+        ServerConfig {
+            name: name.to_string(),
+            dir: "C:/x".to_string(),
+            cmd: "echo test".to_string(),
+            env: HashMap::new(),
+            output: None,
+            port,
+        }
+    }
+
+    #[test]
+    fn detects_external_server_from_port_table() {
+        let mut mgr = ProcessManager::new(
+            vec![test_server("web", Some(43210))],
+            OutputMode::default(),
+        );
+        assert_eq!(mgr.run_state(0), RunState::Stopped);
+
+        mgr.refresh_external_with(&HashMap::from([(43210, 999)]));
+        assert_eq!(mgr.run_state(0), RunState::External);
+
+        // Port gone → back to stopped
+        mgr.refresh_external_with(&HashMap::new());
+        assert_eq!(mgr.run_state(0), RunState::Stopped);
+    }
+
+    #[test]
+    fn server_without_port_never_external() {
+        let mut mgr =
+            ProcessManager::new(vec![test_server("web", None)], OutputMode::default());
+        mgr.refresh_external_with(&HashMap::from([(43210, 999)]));
+        assert_eq!(mgr.run_state(0), RunState::Stopped);
+    }
+
+    #[test]
+    fn start_refuses_when_running_externally() {
+        let mut mgr = ProcessManager::new(
+            vec![test_server("web", Some(43210))],
+            OutputMode::default(),
+        );
+        mgr.refresh_external_with(&HashMap::from([(43210, 999)]));
+        let err = mgr.start(0).unwrap_err();
+        assert!(err.contains("externally"), "unexpected error: {}", err);
+        assert!(err.contains("999"), "unexpected error: {}", err);
+    }
+
+    #[test]
+    fn any_ports_configured_reflects_config() {
+        let mgr = ProcessManager::new(vec![test_server("a", None)], OutputMode::default());
+        assert!(!mgr.any_ports_configured());
+        let mgr = ProcessManager::new(
+            vec![test_server("a", None), test_server("b", Some(80))],
+            OutputMode::default(),
+        );
+        assert!(mgr.any_ports_configured());
     }
 }
 


### PR DESCRIPTION
Closes #24

## Problem
The tray only tracked run-state via the Child handles it spawned itself. A server started outside the app (terminal, AI dev session) showed as `[stopped]` even though it was running — e.g. the reader-app prod PWA frontend.

## Solution
Optional `port` field per `[[server]]`. The app probes Windows' TCP listener table (`GetExtendedTcpTable`, IPv4+IPv6, owner-PID class) and maps listening ports to PIDs.

- **Three run states**: `[running]` (our child), `[external]` (no child, port listening), `[stopped]`
- **Full control of external servers**: Stop kills the detected PID's process tree (`taskkill /F /T`; guarded against PID ≤ 4); Restart then relaunches under app management; Start refuses with "already running externally (PID …)" instead of spawning a bind-doomed duplicate
- **Group counts** treat external as running
- **Refresh Status** menu item, plus auto-refresh on tray-icon hover (throttled 1/sec, skipped when no ports configured) so the menu is current when it opens; menu is swapped in place via `set_menu` — no icon flicker
- **Quit confirmation** now counts external servers (stop-all kills them too)
- **Reload safety**: `spawn_fields_eq` excludes `port`, so annotating a running server with a port + Reload Config doesn't restart it; external processes are never killed by a config reload
- After killing an external process, the port is polled for release (~2s) to avoid port-in-use races on restart

## Tests
First unit tests in the repo (10 passing via `cargo test`): config parsing (port present/absent/out-of-range, `spawn_fields_eq`), port probe (binds real IPv4/IPv6 listeners, finds own PID), detection logic against fake port tables.

## Manual verification (done on the reader app)
Prod frontend started externally → shows `[external]`, group count includes it; Stop kills it (parent terminal survives); Restart adopts it into a managed window; Start on an occupied port errors clearly; Ctrl+C externally + hover → `[stopped]` without clicking Refresh; servers without `port` unchanged.

## Caveat (documented in README)
Detection is purely port-based: an unrelated program listening on a configured port shows as `[external]`, and Stop would kill its process tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
