### PR TITLE
Add GitHub Pages-hosted privacy policy

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,65 @@
+# Privacy Policy — server-start
+
+**Effective date:** 2026-07-13
+
+server-start is a Windows system tray application for starting, stopping, and
+restarting local development servers. It is developed as an open-source
+project; the complete source code is available in this repository.
+
+## Summary
+
+**server-start does not collect, transmit, or share any data. Ever.**
+
+The application has no telemetry, no analytics, no crash reporting, no
+update checks, and no network communication of any kind. It contains no
+networking libraries capable of making outbound connections — you can verify
+this in [`Cargo.toml`](Cargo.toml) and the source code.
+
+## Data the application stores locally
+
+All data stays on your machine and is created only as part of the
+application's core function:
+
+- **Configuration file** — `%APPDATA%\server-start\config.toml`, written by
+  you, containing the commands, working directories, and ports of the dev
+  servers you choose to manage.
+- **Log files (optional)** — when a server's output mode is set to
+  `logfile`, that server's console output is written to a local log file so
+  you can read it. You control this per server in the config.
+- **Registry entry (optional)** — enabling "Start with Windows" writes a
+  single value to your user registry Run key
+  (`HKEY_CURRENT_USER\...\Windows\CurrentVersion\Run`) so Windows launches
+  the app at logon. Disabling the option removes it.
+
+None of this data leaves your computer, and none of it is accessible to the
+project maintainers.
+
+## Local port inspection
+
+To detect dev servers started outside the app, server-start reads the
+Windows TCP listener table (a local operating-system API) to check which
+processes are listening on the ports named in *your* configuration. This is
+a read-only, local lookup. Nothing is connected to, probed over the network,
+or transmitted anywhere.
+
+## Third parties
+
+server-start integrates no third-party services. There are no accounts, no
+sign-ins, no ads, and no data processors.
+
+## Children's privacy
+
+The application collects no data from anyone, including children.
+
+## Changes to this policy
+
+If a future version ever changes any of the above (for example, adding an
+optional update check), this document will be updated in the same release,
+and the change will be listed in the release notes. The version history of
+this file is publicly auditable in the repository's git history.
+
+## Contact
+
+Questions about this policy can be raised by
+[opening an issue](https://github.com/paperhurts/server-start/issues) on
+this repository.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,50 +2,32 @@
 
 **Effective date:** 2026-07-13
 
-server-start is a Windows system tray application for starting, stopping, and
-restarting local development servers. It is developed as an open-source
-project; the complete source code is available in this repository.
+server-start is a Windows system tray application for starting, stopping, and restarting local development servers. It is developed as an open-source project; the complete source code is available in this repository.
 
 ## Summary
 
 **server-start does not collect, transmit, or share any data. Ever.**
 
-The application has no telemetry, no analytics, no crash reporting, no
-update checks, and no network communication of any kind. It contains no
-networking libraries capable of making outbound connections — you can verify
-this in [`Cargo.toml`](Cargo.toml) and the source code.
+The application has no telemetry, no analytics, no crash reporting, no update checks, and no network communication of any kind. It contains no networking libraries capable of making outbound connections — you can verify this in [`Cargo.toml`](Cargo.toml) and the source code.
 
 ## Data the application stores locally
 
 All data stays on your machine and is created only as part of the
 application's core function:
 
-- **Configuration file** — `%APPDATA%\server-start\config.toml`, written by
-  you, containing the commands, working directories, and ports of the dev
-  servers you choose to manage.
-- **Log files (optional)** — when a server's output mode is set to
-  `logfile`, that server's console output is written to a local log file so
-  you can read it. You control this per server in the config.
-- **Registry entry (optional)** — enabling "Start with Windows" writes a
-  single value to your user registry Run key
-  (`HKEY_CURRENT_USER\...\Windows\CurrentVersion\Run`) so Windows launches
-  the app at logon. Disabling the option removes it.
+- **Configuration file** — `%APPDATA%\server-start\config.toml`, written by you, containing the commands, working directories, and ports of the dev servers you choose to manage.
+- **Log files (optional)** — when a server's output mode is set to `logfile`, that server's console output is written to a local log file so you can read it. You control this per server in the config.
+- **Registry entry (optional)** — enabling "Start with Windows" writes a single value to your user registry Run key (`HKEY_CURRENT_USER\...\Windows\CurrentVersion\Run`) so Windows launches the app at logon. Disabling the option removes it.
 
-None of this data leaves your computer, and none of it is accessible to the
-project maintainers.
+None of this data leaves your computer, and none of it is accessible to the project maintainers.
 
 ## Local port inspection
 
-To detect dev servers started outside the app, server-start reads the
-Windows TCP listener table (a local operating-system API) to check which
-processes are listening on the ports named in *your* configuration. This is
-a read-only, local lookup. Nothing is connected to, probed over the network,
-or transmitted anywhere.
+To detect dev servers started outside the app, server-start reads the Windows TCP listener table (a local operating-system API) to check which processes are listening on the ports named in *your* configuration. This is a read-only, local lookup. Nothing is connected to, probed over the network, or transmitted anywhere.
 
 ## Third parties
 
-server-start integrates no third-party services. There are no accounts, no
-sign-ins, no ads, and no data processors.
+server-start integrates no third-party services. There are no accounts, no sign-ins, no ads, and no data processors.
 
 ## Children's privacy
 
@@ -53,13 +35,8 @@ The application collects no data from anyone, including children.
 
 ## Changes to this policy
 
-If a future version ever changes any of the above (for example, adding an
-optional update check), this document will be updated in the same release,
-and the change will be listed in the release notes. The version history of
-this file is publicly auditable in the repository's git history.
+If a future version ever changes any of the above (for example, adding an optional update check), this document will be updated in the same release, and the change will be listed in the release notes. The version history of this file is publicly auditable in the repository's git history.
 
 ## Contact
 
-Questions about this policy can be raised by
-[opening an issue](https://github.com/paperhurts/server-start/issues) on
-this repository.
+Questions about this policy can be raised by [opening an issue](https://github.com/paperhurts/server-start/issues) on this repository.

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -3,7 +3,8 @@
 ## Overview
 Windows system tray app for managing dev servers. Single Rust binary, no runtime deps.
 
-## Current State (2026-07-03)
+## Current State (2026-07-13)
+- **Privacy policy (#27):** `PRIVACY.md` in repo root (no data collection, local-only storage), linked from README. GitHub Pages enabled on `main` (root, default Jekyll) so it's web-hosted at https://paperhurts.github.io/server-start/PRIVACY.html for store listings.
 - **v0.3.0 released** — https://github.com/paperhurts/server-start/releases/tag/v0.3.0
 - **v0.2.0** — https://github.com/paperhurts/server-start/releases/tag/v0.2.0
 - **v0.1.0** — https://github.com/paperhurts/server-start/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ If a `[[server]]` has a `port`, the app checks Windows' TCP listener table for i
 
 ## Privacy
 
-server-start collects no data and makes no network connections — everything stays on your machine. See [PRIVACY.md](PRIVACY.md) for details.
+server-start collects no data and makes no network connections — everything stays on your machine. See [PRIVACY.md](PRIVACY.md) for details, also hosted at [paperhurts.github.io/server-start/PRIVACY.html](https://paperhurts.github.io/server-start/PRIVACY.html).
 
 ## Built With
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ If a `[[server]]` has a `port`, the app checks Windows' TCP listener table for i
 
 > **Caveat:** detection is purely port-based. If an unrelated program happens to listen on a configured port, it will show as `[external]` — and **Stop will kill that program's process tree**. Pick ports that only your dev servers use.
 
+## Privacy
+
+server-start collects no data and makes no network connections — everything stays on your machine. See [PRIVACY.md](PRIVACY.md) for details.
+
 ## Built With
 
 Rust, using [tray-icon](https://crates.io/crates/tray-icon) and [winit](https://crates.io/crates/winit).


### PR DESCRIPTION
Closes #27

## What
- `PRIVACY.md` in the repo root: no data collection or transmission ever; local-only storage (config under `%APPDATA%\server-start`, optional log files, HKCU Run key for autostart); read-only local port inspection; no third parties. Verified against source — no network crates in `Cargo.toml`, no HTTP/telemetry anywhere in `src/`.
- README gains a **Privacy** section linking to it.
- **GitHub Pages is now enabled** on this repo (source: `main` branch, root, default Jekyll). Once this merges, the policy is web-hosted at:

  **https://paperhurts.github.io/server-start/PRIVACY.html**

  This URL is suitable for store listings that require a standalone privacy policy page. Note Pages also renders the README as the site index at https://paperhurts.github.io/server-start/.

## Testing
Docs-only change. After merge, verify the Pages URL above renders (first build takes a minute or two).

🤖 Generated with [Claude Code](https://claude.com/claude-code)